### PR TITLE
fix typo in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The package will be automatically registered via the `MetricPollingServiceProvid
 
 ## Usage
 
-First, add the following trait `use Johnpaulmedina\NoveMetricPolling\ValueInterval` to any of your Nova Metrics
+First, add the following trait `use Johnpaulmedina\NovaMetricPolling\ValueInterval` to any of your Nova Metrics
 
 ```php
 <?php


### PR DESCRIPTION
The typo in code example was very subtle and caught me for a while before I noticed it.

I wanted to correct it for others that also copy out of the docs.